### PR TITLE
feat: make it easy to differentiate between active and inactive tabs

### DIFF
--- a/themes/OLED Pure Black - VSCode-color-theme.json
+++ b/themes/OLED Pure Black - VSCode-color-theme.json
@@ -15,7 +15,7 @@
 		"menu.border": "#424242",
 		"sideBar.background": "#000000",
 		"statusBar.background": "#000000",
-		"tab.inactiveBackground": "#000000",
+		"tab.inactiveBackground": "#424242",
 		"titleBar.activeBackground": "#000000",
 		"titleBar.inactiveBackground": "#000000",
 		// "activityBarBadge.background": "#007acc",


### PR DESCRIPTION
Keeping both active and inactive tabs the same color makes it hard to know which tab is selected. This change remedies that.

![Screenshot 2023-04-28 at 1 49 45 AM](https://user-images.githubusercontent.com/6177621/234981724-73885a9a-989b-4923-972d-bdd093fa4653.png)
